### PR TITLE
Fix time issues with published marker array

### DIFF
--- a/osm_cartography/scripts/osm_server
+++ b/osm_cartography/scripts/osm_server
@@ -82,7 +82,7 @@ class ServerNode:
         else:
             self.resp.success = True
             self.resp.status = url
-            self.resp.map.header.stamp = rospy.Time.now()
+            self.resp.map.header.stamp = rospy.Time()
             self.resp.map.header.frame_id = '/map'
         return self.resp
 

--- a/osm_cartography/scripts/viz_osm
+++ b/osm_cartography/scripts/viz_osm
@@ -235,7 +235,7 @@ class VizNode():
     def timer_callback(self, event):
         """ Called periodically to refresh map visualization. """
         if self.msg is not None:
-            now = rospy.Time.now()
+            now = rospy.Time()
             for m in self.msg.markers:
                 m.header.stamp = now
             self.pub.publish(self.msg)


### PR DESCRIPTION
This PR changes the time stamp of the markers from `rospy.Time.now()` to `rospy.Time(0)`. According to [1]: _"Note that [...] time Zero (0) [...] is treated differently by RViz than any other time. If you use ros::Time::now() or any other non-zero value, rviz will only display the marker if that time is close enough to the current time, where "close enough" depends on TF. With time 0 however, the marker will be displayed regardless of the current time."_

For example, I am using this package combined with robot localization nodes, which is publishing additional tf's. When using `rospy.Time.now()` I was not able to visualize the markers, because according to tf the time stamps were not close enough.

Publishing the markers with `rospy.Time(0)` would make sense in this case, because the markers are static/fixed. Every message will contain the same information. By using `rospy.Time()`, users will be able to change fixed frame in rviz, without running into issues with tf lookups.

[1] http://wiki.ros.org/rviz/DisplayTypes/Marker