### PR TITLE
Remove dependency on rviz from osm_cartography

### DIFF
--- a/osm_cartography/package.xml
+++ b/osm_cartography/package.xml
@@ -25,7 +25,6 @@
   <depend>visualization_msgs</depend>
 
   <exec_depend>route_network</exec_depend>
-  <exec_depend>rviz</exec_depend>
 
   <test_depend>roslaunch</test_depend>
 


### PR DESCRIPTION
rviz isn't a strict requirement for running the map server and people who want to use the rviz functionality probably already have rviz installed.